### PR TITLE
Persist filter values in URL using Option from ts-belt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "music-manager",
       "version": "0.0.1",
       "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "axios": "^1.6.7",
         "pinia": "^2.1.7",
         "vue": "^3.4.15",
@@ -952,6 +953,15 @@
       "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.*"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@mobily/ts-belt": "^3.13.1",
     "axios": "^1.6.7",
     "pinia": "^2.1.7",
     "vue": "^3.4.15",

--- a/src/modules/track/components/TrackFilters.vue
+++ b/src/modules/track/components/TrackFilters.vue
@@ -45,7 +45,7 @@ const sortBy = computed({
 
 const sortOrder = computed({
   get: () => trackStore.sortOrder,
-  set: async (value: 'asc' | 'desc') => {
+  set: async (value: TrackSortOrder) => {
     trackStore.updateSorting(trackStore.sortBy, value);
     await trackStore.fetchTracks();
   },
@@ -88,7 +88,7 @@ const sortOptionsWithKeys = computed(() => {
 const updateSort = async (key: string): Promise<void> => {
   const option = sortOptions.find(opt => `${opt.value}-${opt.order}` === key);
   if (option) {
-    trackStore.updateSorting(option.value, option.order as 'asc' | 'desc');
+    trackStore.updateSorting(option.value, option.order);
     await trackStore.fetchTracks();
   }
 };

--- a/src/modules/track/components/TrackList.vue
+++ b/src/modules/track/components/TrackList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { useTrackStore } from '@/modules/track/store/trackStore';
 import { useModalsPool } from '@/shared/modules/modalsPool/store/modalsPool';
 import TrackListItem from './TrackListItem.vue';
@@ -8,10 +8,6 @@ const trackStore = useTrackStore();
 const modalsStore = useModalsPool();
 
 const bulkSelectMode = ref<boolean>(false);
-
-onMounted(async () => {
-  await trackStore.fetchTracks();
-});
 
 watch(
   () => trackStore.currentPage,

--- a/src/modules/track/components/TrackSearch.vue
+++ b/src/modules/track/components/TrackSearch.vue
@@ -1,18 +1,14 @@
 <script setup lang="ts">
-import { watch } from 'vue';
+import { computed } from 'vue';
 import { useTrackStore } from '@/modules/track/store/trackStore';
-import { useDebounce } from '@/shared/composables/useDebounce';
 
 const trackStore = useTrackStore();
 
-const { value: searchInput, debouncedValue: debouncedSearch } = useDebounce(
-  trackStore.searchQuery,
-  500
-);
-
-watch(debouncedSearch, async newSearch => {
-  trackStore.updateSearchQuery(newSearch);
-  await trackStore.fetchTracks();
+const searchInput = computed({
+  get: () => trackStore.searchQuery,
+  set: (value: string) => {
+    trackStore.updateSearchQuery(value);
+  },
 });
 </script>
 

--- a/src/modules/track/components/modals/DeleteTrack.vue
+++ b/src/modules/track/components/modals/DeleteTrack.vue
@@ -4,9 +4,13 @@ import { useNotificationStore } from '@/shared/modules/notification/store/notifi
 import { useTrackStore } from '@/modules/track/store/trackStore';
 import { useModalsPool } from '@/shared/modules/modalsPool/store/modalsPool';
 import { type Track } from '@/modules/track/types';
-import type { XOR } from '@/shared/types';
 
-const props = defineProps<XOR<{ track: Track }, { trackIds: string[] }>>();
+interface DeleteTrackProps {
+  track?: Track;
+  trackIds?: string[];
+}
+
+const props = defineProps<DeleteTrackProps>();
 
 const modalsStore = useModalsPool();
 

--- a/src/modules/track/composables/useTrackQueries.ts
+++ b/src/modules/track/composables/useTrackQueries.ts
@@ -37,7 +37,7 @@ export interface UseTrackQueriesReturn {
   setFilters: (
     filters: Partial<
       TrackFilters & {
-        sortBy: string;
+        sortBy: TrackSortField;
         sortOrder: TrackSortOrder;
         page: number;
         itemsPerPage: number;
@@ -153,7 +153,7 @@ export function useTrackQueries(): UseTrackQueriesReturn {
   function setFilters(
     filters: Partial<
       TrackFilters & {
-        sortBy: string;
+        sortBy: TrackSortField;
         sortOrder: TrackSortOrder;
         page: number;
         itemsPerPage: number;

--- a/src/modules/track/composables/useTrackQueries.ts
+++ b/src/modules/track/composables/useTrackQueries.ts
@@ -1,4 +1,5 @@
 import { ref, computed, type Ref, type ComputedRef } from 'vue';
+import { O, pipe } from '@mobily/ts-belt';
 import type {
   QueryParams,
   TrackFilters,
@@ -33,6 +34,16 @@ export interface UseTrackQueriesReturn {
   goToPage: (page: number) => void;
   nextPage: () => void;
   previousPage: () => void;
+  setFilters: (
+    filters: Partial<
+      TrackFilters & {
+        sortBy: string;
+        sortOrder: TrackSortOrder;
+        page: number;
+        itemsPerPage: number;
+      }
+    >
+  ) => void;
 }
 
 export function useTrackQueries(): UseTrackQueriesReturn {
@@ -88,6 +99,7 @@ export function useTrackQueries(): UseTrackQueriesReturn {
     sortBy.value = 'createdAt';
     sortOrder.value = 'desc';
     currentPage.value = 1;
+    itemsPerPage.value = 10;
   }
 
   function updateSearchQuery(query: string): void {
@@ -138,6 +150,56 @@ export function useTrackQueries(): UseTrackQueriesReturn {
     }
   }
 
+  function setFilters(
+    filters: Partial<
+      TrackFilters & {
+        sortBy: string;
+        sortOrder: TrackSortOrder;
+        page: number;
+        itemsPerPage: number;
+      }
+    >
+  ): void {
+    pipe(filters, f => {
+      pipe(
+        f.searchQuery,
+        O.fromNullable,
+        O.map(value => (searchQuery.value = value))
+      );
+      pipe(
+        f.selectedGenre,
+        O.fromNullable,
+        O.map(value => (selectedGenre.value = value))
+      );
+      pipe(
+        f.selectedArtist,
+        O.fromNullable,
+        O.map(value => (selectedArtist.value = value))
+      );
+      pipe(
+        f.sortBy,
+        O.fromNullable,
+        O.map(value => (sortBy.value = value))
+      );
+      pipe(
+        f.sortOrder,
+        O.fromNullable,
+        O.map(value => (sortOrder.value = value))
+      );
+      pipe(
+        f.page,
+        O.fromNullable,
+        O.map(value => (currentPage.value = value))
+      );
+      pipe(
+        f.itemsPerPage,
+        O.fromNullable,
+        O.map(value => (itemsPerPage.value = value))
+      );
+      return f;
+    });
+  }
+
   return {
     // State
     searchQuery,
@@ -164,5 +226,6 @@ export function useTrackQueries(): UseTrackQueriesReturn {
     goToPage,
     nextPage,
     previousPage,
+    setFilters,
   };
 }

--- a/src/modules/track/composables/useUrlFilters.ts
+++ b/src/modules/track/composables/useUrlFilters.ts
@@ -1,14 +1,14 @@
 import { ref, watch, type Ref } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
-import { O, pipe } from '@mobily/ts-belt';
+import { O, pipe, type Option } from '@mobily/ts-belt';
 import { useDebounce } from '@/shared/composables/useDebounce';
-import type { TrackSortOrder } from '../types';
+import type { TrackSortField, TrackSortOrder } from '../types';
 
 export interface UrlFilters {
   search?: string;
   genre?: string;
   artist?: string;
-  sortBy?: string;
+  sortBy?: TrackSortField;
   sortOrder?: TrackSortOrder;
   page?: number;
   itemsPerPage?: number;
@@ -27,8 +27,8 @@ export function useUrlFilters(): UseUrlFiltersReturn {
   const route = useRoute();
   const isInitialized = ref(false);
 
-  const getQueryParam = (key: string) =>
-    pipe(
+  const getQueryParam = (key: string): Option<string> => {
+    return pipe(
       route.query[key],
       O.fromNullable,
       O.flatMap(value => (Array.isArray(value) ? pipe(value[0], O.fromNullable) : O.Some(value))),
@@ -36,6 +36,7 @@ export function useUrlFilters(): UseUrlFiltersReturn {
         typeof value === 'string' && value.trim() !== '' ? O.Some(value.trim()) : O.None
       )
     );
+  };
 
   const parseToNumber = (value: string) =>
     pipe(parseInt(value, 10), parsed => (isNaN(parsed) ? O.None : O.Some(parsed)));
@@ -65,7 +66,7 @@ export function useUrlFilters(): UseUrlFiltersReturn {
         return artist;
       });
       O.map(getQueryParam('sortBy'), sortBy => {
-        filters.sortBy = sortBy;
+        filters.sortBy = sortBy as TrackSortField;
         return sortBy;
       });
 

--- a/src/modules/track/composables/useUrlFilters.ts
+++ b/src/modules/track/composables/useUrlFilters.ts
@@ -1,0 +1,165 @@
+import { ref, watch, type Ref } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { O, pipe } from '@mobily/ts-belt';
+import { useDebounce } from '@/shared/composables/useDebounce';
+import type { TrackSortOrder } from '../types';
+
+export interface UrlFilters {
+  search?: string;
+  genre?: string;
+  artist?: string;
+  sortBy?: string;
+  sortOrder?: TrackSortOrder;
+  page?: number;
+  itemsPerPage?: number;
+}
+
+export interface UseUrlFiltersReturn {
+  initializeFromUrl: () => UrlFilters;
+  updateUrl: (filters: UrlFilters) => void;
+  updateUrlDebounced: (filters: UrlFilters) => void;
+  clearUrl: () => void;
+  isInitialized: Ref<boolean>;
+}
+
+export function useUrlFilters(): UseUrlFiltersReturn {
+  const router = useRouter();
+  const route = useRoute();
+  const isInitialized = ref(false);
+
+  const getQueryParam = (key: string) =>
+    pipe(
+      route.query[key],
+      O.fromNullable,
+      O.flatMap(value => (Array.isArray(value) ? pipe(value[0], O.fromNullable) : O.Some(value))),
+      O.flatMap(value =>
+        typeof value === 'string' && value.trim() !== '' ? O.Some(value.trim()) : O.None
+      )
+    );
+
+  const parseToNumber = (value: string) =>
+    pipe(parseInt(value, 10), parsed => (isNaN(parsed) ? O.None : O.Some(parsed)));
+
+  const validateSortOrder = (value: string) =>
+    pipe(value, order =>
+      ['asc', 'desc'].includes(order) ? O.Some(order as TrackSortOrder) : O.None
+    );
+
+  const validatePositiveNumber = (value: number) => (value > 0 ? O.Some(value) : O.None);
+
+  const validateItemsPerPage = (value: number) =>
+    [10, 20, 50, 100].includes(value) ? O.Some(value) : O.None;
+
+  function initializeFromUrl(): UrlFilters {
+    return pipe({} as UrlFilters, filters => {
+      O.map(getQueryParam('search'), search => {
+        filters.search = search;
+        return search;
+      });
+      O.map(getQueryParam('genre'), genre => {
+        filters.genre = genre;
+        return genre;
+      });
+      O.map(getQueryParam('artist'), artist => {
+        filters.artist = artist;
+        return artist;
+      });
+      O.map(getQueryParam('sortBy'), sortBy => {
+        filters.sortBy = sortBy;
+        return sortBy;
+      });
+
+      O.map(pipe(getQueryParam('sortOrder'), O.flatMap(validateSortOrder)), sortOrder => {
+        filters.sortOrder = sortOrder;
+        return sortOrder;
+      });
+
+      O.map(
+        pipe(getQueryParam('page'), O.flatMap(parseToNumber), O.flatMap(validatePositiveNumber)),
+        page => {
+          filters.page = page;
+          return page;
+        }
+      );
+
+      O.map(
+        pipe(
+          getQueryParam('itemsPerPage'),
+          O.flatMap(parseToNumber),
+          O.flatMap(validateItemsPerPage)
+        ),
+        itemsPerPage => {
+          filters.itemsPerPage = itemsPerPage;
+          return itemsPerPage;
+        }
+      );
+
+      isInitialized.value = true;
+      return filters;
+    });
+  }
+
+  const buildQuery = (filters: UrlFilters): Record<string, string> => {
+    const defaultValues = {
+      page: 1,
+      itemsPerPage: 10,
+      sortBy: 'createdAt',
+      sortOrder: 'desc' as const,
+    };
+
+    return pipe(Object.entries(filters) as Array<[keyof UrlFilters, any]>, entries =>
+      entries.reduce(
+        (acc, [key, value]) => {
+          if (value === undefined || value === null || value === '') return acc;
+
+          if (key in defaultValues && value === defaultValues[key as keyof typeof defaultValues]) {
+            return acc;
+          }
+
+          acc[key] = value.toString();
+          return acc;
+        },
+        {} as Record<string, string>
+      )
+    );
+  };
+
+  function updateUrl(filters: UrlFilters): void {
+    if (!isInitialized.value) return;
+
+    const query = buildQuery(filters);
+
+    router.replace({
+      path: route.path,
+      query: Object.keys(query).length > 0 ? query : {},
+    });
+  }
+
+  const { value: filtersInput, debouncedValue: debouncedFilters } = useDebounce<UrlFilters | null>(
+    null,
+    500
+  );
+
+  watch(debouncedFilters, filters => {
+    if (filters) {
+      updateUrl(filters);
+    }
+  });
+
+  function updateUrlDebounced(filters: UrlFilters): void {
+    filtersInput.value = filters;
+  }
+
+  function clearUrl(): void {
+    if (!isInitialized.value) return;
+    router.replace({ path: route.path, query: {} });
+  }
+
+  return {
+    initializeFromUrl,
+    updateUrl,
+    updateUrlDebounced,
+    clearUrl,
+    isInitialized,
+  };
+}

--- a/src/modules/track/store/trackStore.ts
+++ b/src/modules/track/store/trackStore.ts
@@ -147,7 +147,9 @@ export const useTrackStore = defineStore('track', () => {
 
     startFilterSync();
 
-    await fetchTracks();
+    if (Object.keys(urlData).length <= 0) {
+      await fetchTracks();
+    }
 
     isInitializing.value = false;
   }

--- a/src/modules/track/store/trackStore.ts
+++ b/src/modules/track/store/trackStore.ts
@@ -1,9 +1,12 @@
-import { ref, computed, type Ref, type ComputedRef } from 'vue';
+import { ref, computed, watch, type Ref, type ComputedRef } from 'vue';
 import { defineStore } from 'pinia';
+import { O, pipe } from '@mobily/ts-belt';
 
 import type { Track, TrackFormData } from '@/modules/track/types';
 import { useTrackQueries } from '@/modules/track/composables/useTrackQueries';
 import { useTrackSelection } from '@/modules/track/composables/useTrackSelection';
+import { useUrlFilters, type UrlFilters } from '@/modules/track/composables/useUrlFilters';
+import { useDebounce } from '@/shared/composables/useDebounce';
 import { trackApi } from '@/modules/track/api/trackApi';
 
 export const useTrackStore = defineStore('track', () => {
@@ -11,21 +14,160 @@ export const useTrackStore = defineStore('track', () => {
   const tracks = ref<Track[]>([]);
   const totalTracks = ref<number>(0);
   const loading = ref<boolean>(false);
+  const isInitializing = ref<boolean>(true);
 
   // === COMPOSABLES ===
   const trackQueries = useTrackQueries();
   const trackSelection = useTrackSelection();
+  const urlFilters = useUrlFilters();
+
+  const { value: searchInput, debouncedValue: debouncedSearch } = useDebounce('', 500);
 
   // === COMPUTED ===
   const totalPages: ComputedRef<number> = computed(() =>
     Math.ceil(totalTracks.value / trackQueries.itemsPerPage.value)
   );
 
+  const buildUrlFilters = (): UrlFilters => {
+    const filters: UrlFilters = {};
+
+    pipe(
+      debouncedSearch.value,
+      search => (search.trim() !== '' ? O.Some(search.trim()) : O.None),
+      O.map(search => {
+        filters.search = search;
+        return search;
+      })
+    );
+
+    pipe(
+      trackQueries.selectedGenre.value,
+      O.fromNullable,
+      O.map(genre => {
+        filters.genre = genre;
+        return genre;
+      })
+    );
+
+    pipe(
+      trackQueries.selectedArtist.value,
+      O.fromNullable,
+      O.map(artist => {
+        filters.artist = artist;
+        return artist;
+      })
+    );
+
+    pipe(
+      trackQueries.sortBy.value,
+      sortBy => (sortBy !== 'createdAt' ? O.Some(sortBy) : O.None),
+      O.map(sortBy => {
+        filters.sortBy = sortBy;
+        return sortBy;
+      })
+    );
+
+    pipe(
+      trackQueries.sortOrder.value,
+      sortOrder => (sortOrder !== 'desc' ? O.Some(sortOrder) : O.None),
+      O.map(sortOrder => {
+        filters.sortOrder = sortOrder;
+        return sortOrder;
+      })
+    );
+
+    pipe(
+      trackQueries.currentPage.value,
+      page => (page > 1 ? O.Some(page) : O.None),
+      O.map(page => {
+        filters.page = page;
+        return page;
+      })
+    );
+
+    pipe(
+      trackQueries.itemsPerPage.value,
+      items => (items !== 10 ? O.Some(items) : O.None),
+      O.map(items => {
+        filters.itemsPerPage = items;
+        return items;
+      })
+    );
+
+    return filters;
+  };
+
+  function startFilterSync(): void {
+    watch(trackQueries.searchQuery, newSearch => {
+      if (isInitializing.value) return;
+      searchInput.value = newSearch;
+    });
+
+    watch(
+      [
+        debouncedSearch,
+        trackQueries.selectedGenre,
+        trackQueries.selectedArtist,
+        trackQueries.sortBy,
+        trackQueries.sortOrder,
+        trackQueries.currentPage,
+        trackQueries.itemsPerPage,
+      ],
+      async () => {
+        if (!urlFilters.isInitialized.value || isInitializing.value) return;
+
+        try {
+          const filters = buildUrlFilters();
+          urlFilters.updateUrl(filters);
+          await fetchTracks();
+        } catch (error) {
+          console.error('Error in unified filter sync:', error);
+        }
+      }
+    );
+  }
+
+  async function initializeStore(): Promise<void> {
+    isInitializing.value = true;
+
+    const urlData = urlFilters.initializeFromUrl();
+
+    searchInput.value = urlData.search || '';
+
+    trackQueries.setFilters({
+      searchQuery: urlData.search || '',
+      selectedGenre: urlData.genre || null,
+      selectedArtist: urlData.artist || null,
+      sortBy: urlData.sortBy || 'createdAt',
+      sortOrder: urlData.sortOrder || 'desc',
+      page: urlData.page || 1,
+      itemsPerPage: urlData.itemsPerPage || 10,
+    });
+
+    startFilterSync();
+
+    await fetchTracks();
+
+    isInitializing.value = false;
+  }
+
   // === API ACTIONS ===
   async function fetchTracks(): Promise<void> {
+    if (loading.value) {
+      console.log('fetchTracks: Already loading, skipping...');
+      return;
+    }
+
     loading.value = true;
     try {
       const params = trackQueries.buildQueryParams();
+
+      if (debouncedSearch.value && debouncedSearch.value.trim() !== '') {
+        params.search = debouncedSearch.value.trim();
+      } else {
+        delete params.search;
+      }
+
       const { data, meta } = await trackApi.getAllTracks(params);
       tracks.value = data;
       totalTracks.value = meta.total;
@@ -120,6 +262,11 @@ export const useTrackStore = defineStore('track', () => {
     }
   }
 
+  function resetFilters(): void {
+    trackQueries.resetFilters();
+    urlFilters.clearUrl();
+  }
+
   return {
     // State
     tracks: tracks as Ref<Track[]>,
@@ -136,6 +283,7 @@ export const useTrackStore = defineStore('track', () => {
     ...trackSelection,
 
     // Actions
+    initializeStore,
     fetchTracks,
     createTrack,
     updateTrack,
@@ -143,5 +291,8 @@ export const useTrackStore = defineStore('track', () => {
     deleteTracks,
     uploadTrackFile,
     deleteTrackFile,
+    resetFilters,
+
+    isInitialized: urlFilters.isInitialized,
   };
 });

--- a/src/modules/track/store/trackStore.ts
+++ b/src/modules/track/store/trackStore.ts
@@ -14,6 +14,7 @@ export const useTrackStore = defineStore('track', () => {
   const tracks = ref<Track[]>([]);
   const totalTracks = ref<number>(0);
   const loading = ref<boolean>(false);
+  const isFetching = ref<boolean>(false);
   const isInitializing = ref<boolean>(true);
 
   // === COMPOSABLES ===
@@ -153,12 +154,13 @@ export const useTrackStore = defineStore('track', () => {
 
   // === API ACTIONS ===
   async function fetchTracks(): Promise<void> {
-    if (loading.value) {
+    if (isFetching.value) {
       console.log('fetchTracks: Already loading, skipping...');
       return;
     }
 
     loading.value = true;
+    isFetching.value = true;
     try {
       const params = trackQueries.buildQueryParams();
 
@@ -176,6 +178,7 @@ export const useTrackStore = defineStore('track', () => {
       throw error;
     } finally {
       loading.value = false;
+      isFetching.value = false;
     }
   }
 

--- a/src/modules/track/types/index.ts
+++ b/src/modules/track/types/index.ts
@@ -65,10 +65,10 @@ export interface TrackFilters {
   selectedArtist: string | null;
 }
 
-export interface TrackSorting {
-  sortBy: string;
-  sortOrder: 'asc' | 'desc';
-}
-
 export type TrackSortField = NonNullable<QueryParams['sort']>;
 export type TrackSortOrder = NonNullable<QueryParams['order']>;
+
+export interface TrackSorting {
+  sortBy: TrackSortField;
+  sortOrder: TrackSortOrder;
+}

--- a/src/pages/Tracks.vue
+++ b/src/pages/Tracks.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
+import { useTrackStore } from '@/modules/track/store/trackStore';
 import TrackSummary from '@/modules/track/components/TrackSummary.vue';
 import TrackSearch from '@/modules/track/components/TrackSearch.vue';
 import TrackFilters from '@/modules/track/components/TrackFilters.vue';
 import TrackList from '@/modules/track/components/TrackList.vue';
+
+const trackStore = useTrackStore();
+trackStore.initializeStore();
 </script>
 
 <template>

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,12 +1,2 @@
 // Utility types
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-
-/**
- * XOR type
- * @description Returns a type that is either T or U, but not both
- * @example
- * type A = { a: string };
- * type B = { b: number };
- * type C = XOR<A, B>; // C is either { a: string } or { b: number }
- */
-export type XOR<T, U> = (T & { [K in keyof U]?: never }) | (U & { [K in keyof T]?: never });


### PR DESCRIPTION
 Implemented URL persistence for filter values to improve user experience.
 Used Option from [ts-belt](https://mobily.github.io/ts-belt/api/option) to handle potentially missing values safely.

#### Changes include:
- Saving filter state to the URL on change
- Reading filter values from the URL on app initialization
- Using Option for robust value handling
- Bugs fix